### PR TITLE
templates/base: Shade alternating table rows

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,8 @@
       text-align: left;
       padding: 0.25em 0.5em;
     }
+    tbody > tr:nth-child(odd)  { background-color:#eee; }
+    tbody > tr:nth-child(even) { background-color:#fff; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
This is more readable, as it is then clear what belongs to the same row.
