### PR TITLE
Add 'dark mode' based on the Solarized palette

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,16 +5,45 @@
   <title>{% block title %}{% if page_title %}{{ page_title }}{% else %}{{ site_title }}{% endif %}{% endblock %}</title>
   <style>
     body {
+      /* Solarized color palette */
+      --base03:  lab(15% -12 -12);
+      --base02:  lab(20% -12 -12);
+      --base01:  lab(45% -07 -07);
+      --base00:  lab(50% -07 -07);
+      --base0:   lab(60% -06 -03);
+      --base1:   lab(65% -05 -02);
+      --base2:   lab(92% -00  10);
+      --base3:   lab(97%  00  10);
+      --yellow:  lab(60%  10  65);
+      --orange:  lab(50%  50  55);
+      --red:     lab(50%  65  45);
+      --magenta: lab(50%  65 -05);
+      --violet:  lab(50%  15 -45);
+      --blue:    lab(55% -10 -45);
+      --cyan:    lab(60% -35 -05);
+      --green:   lab(60% -20  65);
+
+      /* Functions in Solarized light */
+      --background: var(--base3);
+      --bghilights: var(--base2);
+      --secondary:  var(--base1);
+      --primary:    var(--base00);
+      --emphasis:   vat(--base01);
+
       font-family: sans-serif;
       width: 80ch;
       margin: auto;
+
+      background-color: var(--background);
+      color: var(--primary);
     }
     th, td {
       text-align: left;
       padding: 0.25em 0.5em;
     }
-    tbody > tr:nth-child(odd)  { background-color:#eee; }
-    tbody > tr:nth-child(even) { background-color:#fff; }
+    thead > tr                 { background-color: var(--bghilights); }
+    tbody > tr:nth-child(even) { background-color: var(--bghilights); }
+    tbody > tr:nth-child(odd)  { background-color: var(--background); }
   </style>
 </head>
 <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <title>{% block title %}{% if page_title %}{{ page_title }}{% else %}{{ site_title }}{% endif %}{% endblock %}</title>
   <style>
+    /* Fallback color palette definition in sRGB gamut.  */
     html {
-      /* Solarized color palette */
       --base03:  #002b36;
       --base02:  #073642;
       --base01:  #586e75;
@@ -24,16 +24,10 @@
       --green:   #859900;
     }
 
+    /* Transparent upgrade to CIELAB gamut */
     @supports (color: lab(0% 0 0)) {
       html {
-        --base03:  lab(15% -12 -12);
-        --base02:  lab(20% -12 -12);
-        --base01:  lab(45% -07 -07);
-        --base00:  lab(50% -07 -07);
-        --base0:   lab(60% -06 -03);
-        --base1:   lab(65% -05 -02);
-        --base2:   lab(92% -00  10);
-        --base3:   lab(97%  00  10);
+        /* Accent colors */
         --yellow:  lab(60%  10  65);
         --orange:  lab(50%  50  55);
         --red:     lab(50%  65  45);
@@ -42,21 +36,31 @@
         --blue:    lab(55% -10 -45);
         --cyan:    lab(60% -35 -05);
         --green:   lab(60% -20  65);
+
+        /* Base colors; do not use directly, instead refer to the "roles" defined next. */
+        --base03:  lab(15% -12 -12);
+        --base02:  lab(20% -12 -12);
+        --base01:  lab(45% -07 -07);
+        --base00:  lab(50% -07 -07);
+        --base0:   lab(60% -06 -03);
+        --base1:   lab(65% -05 -02);
+        --base2:   lab(92% -00  10);
+        --base3:   lab(97%  00  10);
       }
     }
 
-    /* Functions in Solarized light */
+    /* Variant-independent "roles" for light mode… */
     @media (prefers-color-scheme: light) {
       html {
-        --background: var(--base3);
-        --bghilights: var(--base2);
-        --secondary:  var(--base1);
-        --primary:    var(--base00);
-        --emphasis:   vat(--base01);
+        --background: var(--base3);  /* The canvas' background. */
+        --bghilights: var(--base2);  /* Background for hilighted regions. */
+        --secondary:  var(--base1);  /* De-emphasized foreground elements. */
+        --primary:    var(--base00); /* Primary foreground elements. */
+        --emphasis:   vat(--base01); /* Emphasized foreground elements. */
       }
     }
 
-    /* Functions in Solarized dark */
+    /* … and dark mode */
     @media (prefers-color-scheme: dark) {
       html {
         --background: var(--base03);
@@ -76,6 +80,7 @@
       color: var(--primary);
     }
 
+    /* Keep the blue/violet convention for links. */
     a {
       color: var(--blue);
     }
@@ -83,10 +88,12 @@
       color: var(--violet);
     }
 
+    /* Styling for (data) tables */
     th, td {
       text-align: left;
       padding: 0.25em 0.5em;
     }
+    /* Hilight the background of header(s) and alternating rows. */
     thead > tr                 { background-color: var(--bghilights); }
     tbody > tr:nth-child(even) { background-color: var(--bghilights); }
     tbody > tr:nth-child(odd)  { background-color: var(--background); }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>{% block title %}{% if page_title %}{{ page_title }}{% else %}{{ site_title }}{% endif %}{% endblock %}</title>
   <style>
-    body {
+    html {
       /* Solarized color palette */
       --base03:  #002b36;
       --base02:  #073642;
@@ -25,7 +25,7 @@
     }
 
     @supports (color: lab(0% 0 0)) {
-      body {
+      html {
         --base03:  lab(15% -12 -12);
         --base02:  lab(20% -12 -12);
         --base01:  lab(45% -07 -07);
@@ -47,7 +47,7 @@
 
     /* Functions in Solarized light */
     @media (prefers-color-scheme: light) {
-      body {
+      html {
         --background: var(--base3);
         --bghilights: var(--base2);
         --secondary:  var(--base1);
@@ -58,7 +58,7 @@
 
     /* Functions in Solarized dark */
     @media (prefers-color-scheme: dark) {
-      body {
+      html {
         --background: var(--base03);
         --bghilights: var(--base02);
         --secondary:  var(--base01);
@@ -67,7 +67,7 @@
       }
     }
 
-    body {
+    html {
       font-family: sans-serif;
       width: 80ch;
       margin: auto;

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,14 +22,31 @@
       --blue:    lab(55% -10 -45);
       --cyan:    lab(60% -35 -05);
       --green:   lab(60% -20  65);
+    }
 
-      /* Functions in Solarized light */
-      --background: var(--base3);
-      --bghilights: var(--base2);
-      --secondary:  var(--base1);
-      --primary:    var(--base00);
-      --emphasis:   vat(--base01);
+    /* Functions in Solarized light */
+    @media (prefers-color-scheme: light) {
+      body {
+        --background: var(--base3);
+        --bghilights: var(--base2);
+        --secondary:  var(--base1);
+        --primary:    var(--base00);
+        --emphasis:   vat(--base01);
+      }
+    }
 
+    /* Functions in Solarized dark */
+    @media (prefers-color-scheme: dark) {
+      body {
+        --background: var(--base03);
+        --bghilights: var(--base02);
+        --secondary:  var(--base01);
+        --primary:    var(--base0);
+        --emphasis:   var(--base1);
+      }
+    }
+
+    body {
       font-family: sans-serif;
       width: 80ch;
       margin: auto;

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,14 @@
       background-color: var(--background);
       color: var(--primary);
     }
+
+    a {
+      color: var(--blue);
+    }
+    a:visited {
+      color: var(--violet);
+    }
+
     th, td {
       text-align: left;
       padding: 0.25em 0.5em;

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,22 +6,43 @@
   <style>
     body {
       /* Solarized color palette */
-      --base03:  lab(15% -12 -12);
-      --base02:  lab(20% -12 -12);
-      --base01:  lab(45% -07 -07);
-      --base00:  lab(50% -07 -07);
-      --base0:   lab(60% -06 -03);
-      --base1:   lab(65% -05 -02);
-      --base2:   lab(92% -00  10);
-      --base3:   lab(97%  00  10);
-      --yellow:  lab(60%  10  65);
-      --orange:  lab(50%  50  55);
-      --red:     lab(50%  65  45);
-      --magenta: lab(50%  65 -05);
-      --violet:  lab(50%  15 -45);
-      --blue:    lab(55% -10 -45);
-      --cyan:    lab(60% -35 -05);
-      --green:   lab(60% -20  65);
+      --base03:  #002b36;
+      --base02:  #073642;
+      --base01:  #586e75;
+      --base00:  #657b83;
+      --base0:   #839496;
+      --base1:   #93a1a1;
+      --base2:   #eee8d5;
+      --base3:   #fdf6e3;
+      --yellow:  #b58900;
+      --orange:  #cb4b16;
+      --red:     #dc322f;
+      --magenta: #d33682;
+      --violet:  #6c71c4;
+      --blue:    #268bd2;
+      --cyan:    #2aa198;
+      --green:   #859900;
+    }
+
+    @supports (color: lab(0% 0 0)) {
+      body {
+        --base03:  lab(15% -12 -12);
+        --base02:  lab(20% -12 -12);
+        --base01:  lab(45% -07 -07);
+        --base00:  lab(50% -07 -07);
+        --base0:   lab(60% -06 -03);
+        --base1:   lab(65% -05 -02);
+        --base2:   lab(92% -00  10);
+        --base3:   lab(97%  00  10);
+        --yellow:  lab(60%  10  65);
+        --orange:  lab(50%  50  55);
+        --red:     lab(50%  65  45);
+        --magenta: lab(50%  65 -05);
+        --violet:  lab(50%  15 -45);
+        --blue:    lab(55% -10 -45);
+        --cyan:    lab(60% -35 -05);
+        --green:   lab(60% -20  65);
+      }
     }
 
     /* Functions in Solarized light */


### PR DESCRIPTION
- [x] Switch to Solarized color palette
  - Introduced CSS variables for the palette's nomenclature
  - Introduced "functional names" for background, primary content, etc.
    See [the Solarized documentation](https://ethanschoonover.com/solarized/#usage-development)
- [x] Add "dark mode" based on user preferences.
  Achieved by setting the "functional names" based on the `prefers-color-scheme` CSS media property.
- [x] Replace the navigator's default colors for links etc.
